### PR TITLE
Switch to MIT License for broader use

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,98 +1,23 @@
-# 📜 LICENSE
+cat > LICENSE.md << 'EOF'
+MIT License
 
-## 🔒 Dual License Structure
+Copyright (c) 2025 William Stetar
 
-This repository is licensed under a **dual-regime license** that distinguishes between:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. **Code (executable logic, scripts, tooling)**  
-2. **Content (philosophical artifacts, typologies, collapse logs, and documentation)**
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
----
-
-## 1. 🧠 Content License — Creative Commons BY-NC-SA 4.0  
-Applies to:
-- `philosophy/` (excluding `semiotic_engine/`)
-- All `.md` documentation files
-- All YAML contradiction logs and typologies
-
-```
-CC-BY-NC-SA 4.0 International
-```
-
-You may:
-- Share, adapt, remix — for **non-commercial** use
-- Must **attribute the original author**
-- Must **license derivatives** under the same terms
-
-> 🔗 Full license text: [creativecommons.org/licenses/by-nc-sa/4.0](https://creativecommons.org/licenses/by-nc-sa/4.0)
-
----
-
-## 2. ⚙️ Code License — GNU AGPLv3  
-Applies to:
-- `scripts/`
-- `semiotic_engine/`
-- Any `.sh`, `.py`, `.lark`, or `.json` files not explicitly marked as philosophical content
-
-```
-GNU Affero General Public License v3.0
-```
-
-You must:
-- Share **source code** of any public-facing forks or services
-- Maintain **derivative openness**
-- Preserve all license and copyright notices
-
-> 🔗 Full license text: [gnu.org/licenses/agpl-3.0](https://www.gnu.org/licenses/agpl-3.0.html)
-
----
-
-## ⚠️ Commercial Use Prohibited  
-Use of any part of this repository in commercial products, platforms, or for-profit workflows is **prohibited without explicit permission**.
-
-If your project or institution wishes to negotiate alternate licensing for integration or research, contact the maintainer.
-
----
-
-## 🤝 Contributions
-
-All contributors agree to the system’s **epistemic integrity model**, including:
-
-- Ontological boundary enforcement between `artifact/` and `system/` domains
-- Immutable trace requirements for all philosophical generations
-- Breach logging and mutation validation
-
-Before contributing, read the following:
-
-- [`CONTRIBUTING.md`](philosophy/docs/CONTRIBUTING.md)
-- [`CONTRIBUTING_Separation_of_Concerns.md`](philosophy/docs/CONTRIBUTING_Separation_of_Concerns.md)
-
-> 🧬 By submitting a pull request, you agree to preserve the falsifiability conditions, symbolic drift contracts, and epistemic lineage protocols defined in the repository.
-
----
-
-## 🧠 Attribution Notice
-
-If citing or referencing this system in scholarly, creative, or technical work, please use the following attribution:
-
-> **Symbolic Grammar Interpreter** — Rhetorical-computational framework for epistemic trace generation, contradiction metabolism, and semiotic drift validation.  
-> Source: https://github.com/YOUR_REPO_URL  
-> License: CC-BY-NC-SA 4.0 + AGPLv3
-
----
-
-## 🧩 Summary Table
-
-| Zone | Path Pattern | License | Modifications Allowed? | Commercial Use |
-|------|--------------|---------|-------------------------|----------------|
-| Philosophical Artifacts | `philosophy/` | CC-BY-NC-SA 4.0 | ✅ ShareAlike | ❌ Forbidden |
-| Docs | `philosophy/docs/*.md` | CC-BY-NC-SA 4.0 | ✅ ShareAlike | ❌ Forbidden |
-| Scripts | `scripts/` | AGPLv3 | ✅ Open-Source | ❌ Forbidden |
-| Engine | `semiotic_engine/` | AGPLv3 | ✅ Open-Source | ❌ Forbidden |
-
----
-
-**This license enforces interpretive autonomy, computational auditability, and recursive epistemic traceability.**  
-If you cannot falsify what you inherit, you are not authorized to evolve it.
-
----
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+EOF


### PR DESCRIPTION
## Switch to MIT License

### Body

Replaces the dual-license structure with a standard MIT License to simplify use and foster broader adoption. See LICENSE.md for full text.